### PR TITLE
adds ability to handle different file types

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,28 @@ var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
 
+/**
+ * @func makeFileContents
+ * @param {string} fileName - the user-inputted filename
+ * @returns the file contents based on the filetype.
+ **/
+function makeFileContents(fileName, { hash }) {
+  let hashString;
+
+  switch(path.extname(fileName)) {
+    case '.json':
+      /* json content should have json obj in the file */
+      hashString = JSON.stringify({ webpackHash: hash });
+      break;
+
+    default:
+      hashString = hash;
+      break;
+  }
+
+  return hashString;
+}
+
 module.exports = function(options) {
   return function() {
 
@@ -12,9 +34,10 @@ module.exports = function(options) {
       if (err) return console.log('Error creating folder:', err);
 
       this.plugin('done', function(stats) {
+
         fs.writeFileSync(
           path.join(outputPath, fileName),
-          stats.hash
+          makeFileContents(fileName, stats),
         );
       });
     }.bind(this));


### PR DESCRIPTION
* Adds the ability to make the output file a `.json` file. 
* Outputs a jsonString with the key: `webpackHash` (see below)
* Allows us to bring the string directly into the current file without parsing or other shenanigans.

#### webpack.config.js
```js
plugins: [
    new HashPlugin({ path: './', fileName: 'webpack-hash.json' }),
],
```

Javascript `require`s automatically parse JSON into JS:

#### server.js
```js 
const { webpackHash } = require('./webpack-hash');
```
